### PR TITLE
feat: add stats tools for sentiment, article counts, and entity spikes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
 
     /* Skip type checking all .d.ts files. */
     "skipLibCheck": true,
-    "types": ["./worker-configuration.d.ts", "node", "vite/client"],
+    "types": ["node"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -343,7 +343,6 @@ async function handleToolRequest(
         } else {
           // For non-authenticated users, require manual API key
           const userPerigonKey = request.headers.get("X-Perigon-API-Key");
-          console.log("Tools endpoint - userPerigonKey 2:", userPerigonKey);
 
           if (!userPerigonKey || userPerigonKey.trim().length === 0) {
             return handleError(

--- a/worker/lib/perigon.ts
+++ b/worker/lib/perigon.ts
@@ -14,6 +14,86 @@ export interface StoryHistoryParams {
   changelogExists?: boolean;
 }
 
+/** Shared article-filter params accepted by all /v1/stats/* endpoints */
+export interface StatsArticleFilters {
+  q?: string;
+  from?: Date;
+  to?: Date;
+  source?: string[];
+  sourceGroup?: string[];
+  category?: string[];
+  topic?: string[];
+  language?: string[];
+  country?: string[];
+  personName?: string[];
+  companyDomain?: string[];
+  companySymbol?: string[];
+}
+
+export type StatsSplitBy = "HOUR" | "DAY" | "WEEK" | "MONTH" | "NONE";
+
+export interface StatsTimeSeriesParams extends StatsArticleFilters {
+  splitBy?: StatsSplitBy;
+}
+
+export interface TopEntitiesParams extends StatsArticleFilters {
+  entity?: string[];
+}
+
+export interface TopSpikeParams extends StatsArticleFilters {
+  currentFrom?: Date;
+  currentTo?: Date;
+  baselineFrom?: Date;
+  baselineTo?: Date;
+  normalizeByDay?: boolean;
+  size?: number;
+}
+
+export interface CountStatDto {
+  pubDate: string;
+  addDate: string;
+  count: number;
+}
+
+export interface AvgSentimentStatDto {
+  pubDate: string;
+  addDate: string;
+  positive: number;
+  negative: number;
+  neutral: number;
+}
+
+export interface StatResult<T> {
+  status: number;
+  numResults: number;
+  results: T[];
+}
+
+export interface EntitySpike {
+  id: string;
+  name: string;
+  currentCount: number;
+  baselineCount: number;
+  spikeScore: number;
+  [key: string]: unknown;
+}
+
+export interface TableSearchResult<T> {
+  status: number;
+  numResults: number;
+  results: T[];
+}
+
+export interface TopEntitiesDto {
+  topics?: unknown[];
+  people?: unknown[];
+  companies?: unknown[];
+  cities?: unknown[];
+  journalists?: unknown[];
+  sources?: unknown[];
+  [key: string]: unknown;
+}
+
 export interface StoryHistoryKeyPoint {
   point: string;
   references: string[];
@@ -54,6 +134,86 @@ export class Perigon extends V1Api {
         },
       },
     );
+  }
+
+  /** Build URLSearchParams from shared article filters used by all /v1/stats/* endpoints */
+  private buildStatsFilters(params: StatsArticleFilters): URLSearchParams {
+    const sp = new URLSearchParams();
+    if (params.q) sp.set("q", params.q);
+    if (params.from) sp.set("from", params.from.toISOString());
+    if (params.to) sp.set("to", params.to.toISOString());
+    if (params.source) for (const s of params.source) sp.append("source", s);
+    if (params.sourceGroup) for (const g of params.sourceGroup) sp.append("sourceGroup", g);
+    if (params.category) for (const c of params.category) sp.append("category", c);
+    if (params.topic) for (const t of params.topic) sp.append("topic", t);
+    if (params.language) for (const l of params.language) sp.append("language", l);
+    if (params.country) for (const c of params.country) sp.append("country", c);
+    if (params.personName) for (const p of params.personName) sp.append("personName", p);
+    if (params.companyDomain) for (const d of params.companyDomain) sp.append("companyDomain", d);
+    if (params.companySymbol) for (const s of params.companySymbol) sp.append("companySymbol", s);
+    return sp;
+  }
+
+  async getAvgSentiment(
+    params: StatsTimeSeriesParams,
+  ): Promise<StatResult<AvgSentimentStatDto>> {
+    const sp = this.buildStatsFilters(params);
+    if (params.splitBy) sp.set("splitBy", params.splitBy);
+    return await typedFetch<StatResult<AvgSentimentStatDto>>(
+      `${BASE_URL}/stats/avgSentiment?${sp.toString()}`,
+      { headers: { Authorization: `Bearer ${this.apiKey}` } },
+    );
+  }
+
+  async getArticleCounts(
+    params: StatsTimeSeriesParams,
+  ): Promise<StatResult<CountStatDto>> {
+    const sp = this.buildStatsFilters(params);
+    if (params.splitBy) sp.set("splitBy", params.splitBy);
+    return await typedFetch<StatResult<CountStatDto>>(
+      `${BASE_URL}/stats/intervalArticleCounts?${sp.toString()}`,
+      { headers: { Authorization: `Bearer ${this.apiKey}` } },
+    );
+  }
+
+  async getTopEntities(params: TopEntitiesParams): Promise<TopEntitiesDto> {
+    const sp = this.buildStatsFilters(params);
+    if (params.entity) for (const e of params.entity) sp.append("entity", e);
+    return await typedFetch<TopEntitiesDto>(
+      `${BASE_URL}/stats/topEntities?${sp.toString()}`,
+      { headers: { Authorization: `Bearer ${this.apiKey}` } },
+    );
+  }
+
+  async getTopPeople(
+    params: TopSpikeParams,
+  ): Promise<TableSearchResult<EntitySpike>> {
+    const sp = this.buildStatsFilters(params);
+    this.applySpikePrams(sp, params);
+    return await typedFetch<TableSearchResult<EntitySpike>>(
+      `${BASE_URL}/stats/topPeople?${sp.toString()}`,
+      { headers: { Authorization: `Bearer ${this.apiKey}` } },
+    );
+  }
+
+  async getTopCompanies(
+    params: TopSpikeParams,
+  ): Promise<TableSearchResult<EntitySpike>> {
+    const sp = this.buildStatsFilters(params);
+    this.applySpikePrams(sp, params);
+    return await typedFetch<TableSearchResult<EntitySpike>>(
+      `${BASE_URL}/stats/topCompanies?${sp.toString()}`,
+      { headers: { Authorization: `Bearer ${this.apiKey}` } },
+    );
+  }
+
+  private applySpikePrams(sp: URLSearchParams, params: TopSpikeParams) {
+    if (params.currentFrom) sp.set("currentFrom", params.currentFrom.toISOString());
+    if (params.currentTo) sp.set("currentTo", params.currentTo.toISOString());
+    if (params.baselineFrom) sp.set("baselineFrom", params.baselineFrom.toISOString());
+    if (params.baselineTo) sp.set("baselineTo", params.baselineTo.toISOString());
+    if (params.normalizeByDay !== undefined) sp.set("normalizeByDay", String(params.normalizeByDay));
+    if (params.size !== undefined) sp.set("size", String(params.size));
   }
 
   async searchStoriesHistory(

--- a/worker/lib/perigon.ts
+++ b/worker/lib/perigon.ts
@@ -1,8 +1,39 @@
 import { Configuration, V1Api } from "@goperigon/perigon-ts";
-import { AuthIntrospectionResponse } from "../types/types";
+import { AuthIntrospectionResponse, HttpError } from "../types/types";
 import { typedFetch } from "./typed-fetch";
 
 const BASE_URL = "https://api.perigon.io/v1";
+
+/**
+ * Retry a typed fetch on transient upstream failures (5xx + 429).
+ * The /v1/stats/* endpoints are computationally heavy and occasionally throw
+ * a 500 with a `reference = <id>` body — those are usually not deterministic
+ * and succeed on a second attempt, so we transparently retry a few times
+ * before bubbling the error up.
+ */
+async function fetchWithRetry<T>(
+  url: string,
+  options: RequestInit,
+  attempts = 3,
+  baseDelayMs = 400,
+): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await typedFetch<T>(url, options);
+    } catch (error) {
+      lastError = error;
+      const isRetryable =
+        error instanceof HttpError &&
+        (error.statusCode >= 500 || error.statusCode === 429);
+      if (!isRetryable || i === attempts - 1) throw error;
+      // exponential backoff with jitter
+      const delay = baseDelayMs * Math.pow(2, i) + Math.random() * 200;
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastError;
+}
 
 export interface StoryHistoryParams {
   clusterId?: string[];
@@ -30,7 +61,8 @@ export interface StatsArticleFilters {
   companySymbol?: string[];
 }
 
-export type StatsSplitBy = "HOUR" | "DAY" | "WEEK" | "MONTH" | "NONE";
+/** Lowercase enum values accepted by the API for `splitBy`. NONE is represented by omitting the param. */
+export type StatsSplitBy = "hour" | "day" | "week" | "month";
 
 export interface StatsTimeSeriesParams extends StatsArticleFilters {
   splitBy?: StatsSplitBy;
@@ -49,49 +81,98 @@ export interface TopSpikeParams extends StatsArticleFilters {
   size?: number;
 }
 
+/** Single bucket from /v1/stats/intervalArticleCounts */
 export interface CountStatDto {
-  pubDate: string;
-  addDate: string;
+  date: string;
+  numResults: number;
+}
+
+/** Single bucket from /v1/stats/avgSentiment */
+export interface AvgSentimentStatDto {
+  date: string;
+  numResults: number;
+  avgSentiment: {
+    positive: number;
+    negative: number;
+    neutral: number;
+  };
+}
+
+/** Generic stats response wrapper (used by interval count + avg sentiment) */
+export interface StatResult<T> {
+  status: number;
+  results: T[];
+}
+
+/** Single ranked entry returned by /v1/stats/topEntities for a given entity bucket */
+export interface TopEntityItem {
+  key: string;
   count: number;
 }
 
-export interface AvgSentimentStatDto {
-  pubDate: string;
-  addDate: string;
-  positive: number;
-  negative: number;
-  neutral: number;
-}
-
-export interface StatResult<T> {
-  status: number;
-  numResults: number;
-  results: T[];
-}
-
-export interface EntitySpike {
-  id: string;
-  name: string;
-  currentCount: number;
-  baselineCount: number;
-  spikeScore: number;
-  [key: string]: unknown;
-}
-
-export interface TableSearchResult<T> {
-  status: number;
-  numResults: number;
-  results: T[];
-}
-
+/**
+ * Response shape for /v1/stats/topEntities. The keys present depend on which
+ * entity types were requested. Each entity bucket is paired with a `total*` field
+ * indicating the size of the universe that was ranked.
+ */
 export interface TopEntitiesDto {
-  topics?: unknown[];
-  people?: unknown[];
-  companies?: unknown[];
-  cities?: unknown[];
-  journalists?: unknown[];
-  sources?: unknown[];
-  [key: string]: unknown;
+  totalArticles?: number;
+  totalTopics?: number;
+  topics?: TopEntityItem[];
+  totalPeople?: number;
+  people?: TopEntityItem[];
+  totalCompanies?: number;
+  companies?: TopEntityItem[];
+  totalCities?: number;
+  cities?: TopEntityItem[];
+  totalJournalists?: number;
+  journalists?: TopEntityItem[];
+  totalSources?: number;
+  sources?: TopEntityItem[];
+}
+
+/** Single entry in /v1/stats/topPeople */
+export interface PersonSpike {
+  wikidataId: string;
+  spikeScore: number;
+  currentMentions: number;
+  baselineMentions: number;
+  currentRatePerDay: number;
+  baselineRatePerDay: number;
+  person: {
+    wikidataId: string;
+    name: string;
+    description?: string | null;
+    occupation?: Array<{ wikidataId: string; label: string }>;
+    [key: string]: unknown;
+  };
+}
+
+/** Single entry in /v1/stats/topCompanies */
+export interface CompanySpike {
+  wikidataId: string;
+  spikeScore: number;
+  currentMentions: number;
+  baselineMentions: number;
+  currentRatePerDay: number;
+  baselineRatePerDay: number;
+  company: {
+    id: string;
+    name: string;
+    domains?: string[];
+    industry?: string | null;
+    sector?: string | null;
+    country?: string | null;
+    description?: string | null;
+    symbols?: Array<{ symbol: string; exchange: string }>;
+    [key: string]: unknown;
+  };
+}
+
+/** Wrapper shape returned by /v1/stats/topPeople and /v1/stats/topCompanies */
+export interface SpikeResult<T> {
+  total: number;
+  data: T[];
 }
 
 export interface StoryHistoryKeyPoint {
@@ -159,7 +240,7 @@ export class Perigon extends V1Api {
   ): Promise<StatResult<AvgSentimentStatDto>> {
     const sp = this.buildStatsFilters(params);
     if (params.splitBy) sp.set("splitBy", params.splitBy);
-    return await typedFetch<StatResult<AvgSentimentStatDto>>(
+    return await fetchWithRetry<StatResult<AvgSentimentStatDto>>(
       `${BASE_URL}/stats/avgSentiment?${sp.toString()}`,
       { headers: { Authorization: `Bearer ${this.apiKey}` } },
     );
@@ -170,7 +251,7 @@ export class Perigon extends V1Api {
   ): Promise<StatResult<CountStatDto>> {
     const sp = this.buildStatsFilters(params);
     if (params.splitBy) sp.set("splitBy", params.splitBy);
-    return await typedFetch<StatResult<CountStatDto>>(
+    return await fetchWithRetry<StatResult<CountStatDto>>(
       `${BASE_URL}/stats/intervalArticleCounts?${sp.toString()}`,
       { headers: { Authorization: `Bearer ${this.apiKey}` } },
     );
@@ -179,7 +260,7 @@ export class Perigon extends V1Api {
   async getTopEntities(params: TopEntitiesParams): Promise<TopEntitiesDto> {
     const sp = this.buildStatsFilters(params);
     if (params.entity) for (const e of params.entity) sp.append("entity", e);
-    return await typedFetch<TopEntitiesDto>(
+    return await fetchWithRetry<TopEntitiesDto>(
       `${BASE_URL}/stats/topEntities?${sp.toString()}`,
       { headers: { Authorization: `Bearer ${this.apiKey}` } },
     );
@@ -187,10 +268,10 @@ export class Perigon extends V1Api {
 
   async getTopPeople(
     params: TopSpikeParams,
-  ): Promise<TableSearchResult<EntitySpike>> {
+  ): Promise<SpikeResult<PersonSpike>> {
     const sp = this.buildStatsFilters(params);
     this.applySpikePrams(sp, params);
-    return await typedFetch<TableSearchResult<EntitySpike>>(
+    return await fetchWithRetry<SpikeResult<PersonSpike>>(
       `${BASE_URL}/stats/topPeople?${sp.toString()}`,
       { headers: { Authorization: `Bearer ${this.apiKey}` } },
     );
@@ -198,10 +279,10 @@ export class Perigon extends V1Api {
 
   async getTopCompanies(
     params: TopSpikeParams,
-  ): Promise<TableSearchResult<EntitySpike>> {
+  ): Promise<SpikeResult<CompanySpike>> {
     const sp = this.buildStatsFilters(params);
     this.applySpikePrams(sp, params);
-    return await typedFetch<TableSearchResult<EntitySpike>>(
+    return await fetchWithRetry<SpikeResult<CompanySpike>>(
       `${BASE_URL}/stats/topCompanies?${sp.toString()}`,
       { headers: { Authorization: `Bearer ${this.apiKey}` } },
     );

--- a/worker/mcp/tools/index.ts
+++ b/worker/mcp/tools/index.ts
@@ -17,6 +17,13 @@
  * - Wikipedia: Search Wikipedia pages with advanced filtering
  * - Wikipedia Vector: Semantic search of Wikipedia using vector embeddings
  *
+ * Stats Tools (Aggregate metrics and trend analysis):
+ * - Avg Sentiment: Average sentiment scores over time
+ * - Article Counts: Article publication volume over time
+ * - Top Entities: Most-mentioned topics, people, companies, cities, and sources
+ * - Top People: People with the biggest coverage spikes
+ * - Top Companies: Companies with the biggest coverage spikes
+ *
  * Use-Case Tools (Simplified workflows for common tasks):
  * - Company News: Get recent news about a specific company
  * - Person News: Get recent news about a specific person
@@ -42,6 +49,13 @@ export { topicsTool } from "./search/topics";
 export { wikipediaTool } from "./search/wikipedia";
 export { wikipediaVectorTool } from "./search/wikipedia-vector";
 
+// Export stats tool definitions
+export { avgSentimentTool } from "./search/stats-avg-sentiment";
+export { articleCountsTool } from "./search/stats-article-counts";
+export { topEntitiesTool } from "./search/stats-top-entities";
+export { topPeopleTool } from "./search/stats-top-people";
+export { topCompaniesTool } from "./search/stats-top-companies";
+
 // Export use-case tools
 export { companyNewsTool } from "./use-cases/company-news";
 export { personNewsTool } from "./use-cases/person-news";
@@ -61,6 +75,13 @@ export { searchTopics } from "./search/topics";
 export { searchWikipedia } from "./search/wikipedia";
 export { searchVectorWikipedia } from "./search/wikipedia-vector";
 
+// Export stats tool functions
+export { getAvgSentiment } from "./search/stats-avg-sentiment";
+export { getArticleCounts } from "./search/stats-article-counts";
+export { getTopEntities } from "./search/stats-top-entities";
+export { getTopPeople } from "./search/stats-top-people";
+export { getTopCompanies } from "./search/stats-top-companies";
+
 // Export use-case tool functions
 export { getCompanyNews } from "./use-cases/company-news";
 export { getPersonNews } from "./use-cases/person-news";
@@ -79,6 +100,13 @@ export { companiesArgs } from "./search/companies";
 export { topicsArgs } from "./search/topics";
 export { wikipediaArgs } from "./search/wikipedia";
 export { wikipediaVectorArgs } from "./search/wikipedia-vector";
+
+// Export stats argument schemas
+export { avgSentimentArgs } from "./search/stats-avg-sentiment";
+export { articleCountsArgs } from "./search/stats-article-counts";
+export { topEntitiesArgs } from "./search/stats-top-entities";
+export { topPeopleArgs } from "./search/stats-top-people";
+export { topCompaniesArgs } from "./search/stats-top-companies";
 
 // Export use-case argument schemas
 export { companyNewsArgs } from "./use-cases/company-news";
@@ -121,6 +149,11 @@ import { companiesTool } from "./search/companies";
 import { topicsTool } from "./search/topics";
 import { wikipediaTool } from "./search/wikipedia";
 import { wikipediaVectorTool } from "./search/wikipedia-vector";
+import { avgSentimentTool } from "./search/stats-avg-sentiment";
+import { articleCountsTool } from "./search/stats-article-counts";
+import { topEntitiesTool } from "./search/stats-top-entities";
+import { topPeopleTool } from "./search/stats-top-people";
+import { topCompaniesTool } from "./search/stats-top-companies";
 import { companyNewsTool } from "./use-cases/company-news";
 import { personNewsTool } from "./use-cases/person-news";
 import { locationNewsTool } from "./use-cases/location-news";
@@ -147,6 +180,13 @@ export const TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
   search_topics: topicsTool,
   search_wikipedia: wikipediaTool,
   search_vector_wikipedia: wikipediaVectorTool,
+
+  // Stats tools
+  get_avg_sentiment: avgSentimentTool,
+  get_article_counts: articleCountsTool,
+  get_top_entities: topEntitiesTool,
+  get_top_people: topPeopleTool,
+  get_top_companies: topCompaniesTool,
 
   // Use-case tools
   get_company_news: companyNewsTool,

--- a/worker/mcp/tools/schemas/stats.ts
+++ b/worker/mcp/tools/schemas/stats.ts
@@ -84,5 +84,13 @@ export const splitByEnum = z
   .enum(["HOUR", "DAY", "WEEK", "MONTH", "NONE"])
   .default("DAY")
   .describe(
-    "Time interval for bucketing results. HOUR = hourly, DAY = daily, WEEK = weekly, MONTH = monthly, NONE = single aggregate value."
+    "Time interval for bucketing results. HOUR = hourly, DAY = daily, WEEK = weekly, MONTH = monthly, NONE = single aggregate value across the whole date range."
   );
+
+/** Convert the user-facing splitBy enum to the lowercase value the API expects, or undefined to omit (NONE). */
+export function normalizeSplitBy(
+  splitBy: "HOUR" | "DAY" | "WEEK" | "MONTH" | "NONE" | undefined
+): "hour" | "day" | "week" | "month" | undefined {
+  if (!splitBy || splitBy === "NONE") return undefined;
+  return splitBy.toLowerCase() as "hour" | "day" | "week" | "month";
+}

--- a/worker/mcp/tools/schemas/stats.ts
+++ b/worker/mcp/tools/schemas/stats.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+function parseTime(str: string) {
+  if (str === "") return undefined;
+  return new Date(str);
+}
+
+/**
+ * Shared article-filter arguments accepted by all /v1/stats/* endpoints.
+ * These mirror the most useful subset of AllEndpointParams for LLM use.
+ */
+export const statsFilterArgs = z.object({
+  q: z
+    .string()
+    .optional()
+    .describe(
+      "Keyword search across article titles, descriptions, and content. Supports Boolean operators (AND, OR, NOT), exact phrases with quotes, and wildcards (* and ?)."
+    ),
+  from: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "Filter articles published after this date. ISO 8601 or yyyy-mm-dd format."
+    ),
+  to: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "Filter articles published before this date. ISO 8601 or yyyy-mm-dd format."
+    ),
+  source: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Filter by publisher domains (e.g., cnn.com, nytimes.com). Wildcards supported."
+    ),
+  sourceGroup: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Filter using curated publisher bundles: top10, top25, top50, top100, top25tech, top25crypto."
+    ),
+  category: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Filter by content categories (e.g., Politics, Tech, Business, Finance). Multiple values use OR logic."
+    ),
+  topic: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Filter by specific topics (e.g., AI, Cryptocurrency, Climate Change). More granular than categories."
+    ),
+  language: z
+    .array(z.string())
+    .optional()
+    .describe("Filter by language using ISO-639 two-letter codes (e.g., en, es, fr)."),
+  country: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Filter by country where the news event is located, using two-letter codes (e.g., us, gb)."
+    ),
+  personName: z
+    .array(z.string())
+    .optional()
+    .describe("Filter articles mentioning specific people by name."),
+  companyDomain: z
+    .array(z.string())
+    .optional()
+    .describe("Filter articles mentioning companies by domain (e.g., apple.com)."),
+  companySymbol: z
+    .array(z.string())
+    .optional()
+    .describe("Filter articles mentioning companies by stock ticker symbol (e.g., AAPL)."),
+});
+
+export type StatsFilterArgs = z.infer<typeof statsFilterArgs>;
+
+export const splitByEnum = z
+  .enum(["HOUR", "DAY", "WEEK", "MONTH", "NONE"])
+  .default("DAY")
+  .describe(
+    "Time interval for bucketing results. HOUR = hourly, DAY = daily, WEEK = weekly, MONTH = monthly, NONE = single aggregate value."
+  );

--- a/worker/mcp/tools/search/news-articles.ts
+++ b/worker/mcp/tools/search/news-articles.ts
@@ -272,6 +272,20 @@ export function searchNewsArticles(perigon: Perigon): ToolCallback {
           article.topics?.map((t) => t.name).join(", ") ?? "";
         const labels =
           article.labels?.map((l) => l.name).join(", ") ?? "";
+        const people =
+          article.people?.map((p) => p.name).filter(Boolean).join(", ") ?? "";
+        const companies =
+          article.companies?.map((c) => c.name).filter(Boolean).join(", ") ?? "";
+        const places =
+          article.places
+            ?.map((p) => [p.city, p.state, p.country].filter(Boolean).join(", "))
+            .filter(Boolean)
+            .join("; ") ?? "";
+        const locations =
+          article.locations
+            ?.map((l) => [l.city, l.state, l.country].filter(Boolean).join(", "))
+            .filter(Boolean)
+            .join("; ") ?? "";
 
         return `<article id="${article.articleId}" title="${article.title}">
 URL: ${article.url}
@@ -284,10 +298,15 @@ Author: ${article.authorsByline}
 Language: ${article.language}
 Country: ${article.country}
 Medium: ${article.medium}
+Reprint: ${article.reprint ?? false}
 Sentiment: ${JSON.stringify(article.sentiment)}
 Categories: ${categories}
 Topics: ${topics}
 Labels: ${labels}
+People: ${people}
+Companies: ${companies}
+Places: ${places}
+Locations: ${locations}
 Story Id: ${article.clusterId}
 Journalist Ids: ${journalistIds}
 </article>`;

--- a/worker/mcp/tools/search/people.ts
+++ b/worker/mcp/tools/search/people.ts
@@ -4,7 +4,14 @@ import { Perigon } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
 import { paginationArgs } from "../schemas/base";
 import { createSearchField } from "../schemas/search";
-import { toolResult, noResults, createPaginationHeader } from "../utils/formatting";
+import {
+  toolResult,
+  noResults,
+  createPaginationHeader,
+  formatLabel,
+  formatLabelList,
+  formatWikidataDate,
+} from "../utils/formatting";
 import { createErrorMessage } from "../utils/error-handling";
 
 /**
@@ -71,12 +78,12 @@ export function searchPeople(perigon: Perigon): ToolCallback {
       if (result.numResults === 0) return noResults;
 
       const people = result.results.map((person) => {
-        return `<person name="${person.name}">
-Occupation: ${person.occupation}
-Position: ${person.position}
-Gender: ${person.gender}
-Date Of Birth: ${person.dateOfBirth}
-Description: ${person.description}
+        return `<person wikidata_id="${person.wikidataId ?? ""}" name="${person.name ?? ""}">
+Occupation: ${formatLabelList(person.occupation)}
+Position: ${formatLabelList(person.position)}
+Gender: ${formatLabel(person.gender)}
+Date Of Birth: ${formatWikidataDate(person.dateOfBirth)}
+Description: ${person.description ?? "N/A"}
 </person>`;
       });
 

--- a/worker/mcp/tools/search/stats-article-counts.ts
+++ b/worker/mcp/tools/search/stats-article-counts.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { Perigon, CountStatDto, StatResult } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
-import { statsFilterArgs, splitByEnum } from "../schemas/stats";
+import { statsFilterArgs, splitByEnum, normalizeSplitBy } from "../schemas/stats";
 import { toolResult, noResults } from "../utils/formatting";
 import { createErrorMessage } from "../utils/error-handling";
 
@@ -26,18 +26,18 @@ export function getArticleCounts(perigon: Perigon): ToolCallback {
         personName: args.personName,
         companyDomain: args.companyDomain,
         companySymbol: args.companySymbol,
-        splitBy: args.splitBy,
+        splitBy: normalizeSplitBy(args.splitBy),
       });
 
       if (!result.results || result.results.length === 0) return noResults;
 
-      const totalArticles = result.results.reduce((sum, r) => sum + r.count, 0);
+      const totalArticles = result.results.reduce((sum, r) => sum + r.numResults, 0);
 
       const rows = result.results.map((r) =>
-        `<count_bucket date="${r.pubDate ?? r.addDate}" count="${r.count}" />`
+        `<count_bucket date="${r.date}" count="${r.numResults}" />`
       );
 
-      let output = `Got ${result.numResults} bucket(s), ${totalArticles} total articles (splitBy=${args.splitBy ?? "DAY"})\n`;
+      let output = `Got ${result.results.length} bucket(s), ${totalArticles} total articles (splitBy=${args.splitBy ?? "DAY"})\n`;
       output += `<article_count_results>\n`;
       output += rows.join("\n");
       output += `\n</article_count_results>`;

--- a/worker/mcp/tools/search/stats-article-counts.ts
+++ b/worker/mcp/tools/search/stats-article-counts.ts
@@ -1,0 +1,61 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { Perigon, CountStatDto, StatResult } from "../../../lib/perigon";
+import { ToolCallback, ToolDefinition } from "../types";
+import { statsFilterArgs, splitByEnum } from "../schemas/stats";
+import { toolResult, noResults } from "../utils/formatting";
+import { createErrorMessage } from "../utils/error-handling";
+
+export const articleCountsArgs = statsFilterArgs.extend({
+  splitBy: splitByEnum.optional(),
+});
+
+export function getArticleCounts(perigon: Perigon): ToolCallback {
+  return async (args: z.infer<typeof articleCountsArgs>): Promise<CallToolResult> => {
+    try {
+      const result: StatResult<CountStatDto> = await perigon.getArticleCounts({
+        q: args.q,
+        from: args.from,
+        to: args.to,
+        source: args.source,
+        sourceGroup: args.sourceGroup,
+        category: args.category,
+        topic: args.topic,
+        language: args.language,
+        country: args.country,
+        personName: args.personName,
+        companyDomain: args.companyDomain,
+        companySymbol: args.companySymbol,
+        splitBy: args.splitBy,
+      });
+
+      if (!result.results || result.results.length === 0) return noResults;
+
+      const totalArticles = result.results.reduce((sum, r) => sum + r.count, 0);
+
+      const rows = result.results.map((r) =>
+        `<count_bucket date="${r.pubDate ?? r.addDate}" count="${r.count}" />`
+      );
+
+      let output = `Got ${result.numResults} bucket(s), ${totalArticles} total articles (splitBy=${args.splitBy ?? "DAY"})\n`;
+      output += `<article_count_results>\n`;
+      output += rows.join("\n");
+      output += `\n</article_count_results>`;
+
+      return toolResult(output);
+    } catch (error) {
+      console.error("Error in get_article_counts:", error);
+      return toolResult(
+        `Error: Failed to retrieve article counts: ${await createErrorMessage(error)}`
+      );
+    }
+  };
+}
+
+export const articleCountsTool: ToolDefinition = {
+  name: "get_article_counts",
+  description:
+    "Get article publication volume bucketed over time for articles matching the given filters. Use this when the user asks about coverage trends, how much a topic was covered over time, or wants a chart/table of article counts — NOT just for finding the total number of articles (use search_news_articles with showNumResults for a simple total count). Returns one count per time bucket. Use splitBy to control the interval (HOUR, DAY, WEEK, MONTH, or NONE for a single total across the whole date range). Supports the same article filters as search_news_articles.",
+  parameters: articleCountsArgs,
+  createHandler: (perigon: Perigon) => getArticleCounts(perigon),
+};

--- a/worker/mcp/tools/search/stats-avg-sentiment.ts
+++ b/worker/mcp/tools/search/stats-avg-sentiment.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { Perigon, AvgSentimentStatDto, StatResult } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
-import { statsFilterArgs, splitByEnum } from "../schemas/stats";
+import { statsFilterArgs, splitByEnum, normalizeSplitBy } from "../schemas/stats";
 import { toolResult, noResults } from "../utils/formatting";
 import { createErrorMessage } from "../utils/error-handling";
 
@@ -26,20 +26,20 @@ export function getAvgSentiment(perigon: Perigon): ToolCallback {
         personName: args.personName,
         companyDomain: args.companyDomain,
         companySymbol: args.companySymbol,
-        splitBy: args.splitBy,
+        splitBy: normalizeSplitBy(args.splitBy),
       });
 
       if (!result.results || result.results.length === 0) return noResults;
 
       const rows = result.results.map((r) =>
-        `<sentiment_bucket date="${r.pubDate ?? r.addDate}">` +
-        `\nPositive: ${r.positive}` +
-        `\nNegative: ${r.negative}` +
-        `\nNeutral: ${r.neutral}` +
+        `<sentiment_bucket date="${r.date}" articles="${r.numResults}">` +
+        `\nPositive: ${r.avgSentiment.positive.toFixed(4)}` +
+        `\nNegative: ${r.avgSentiment.negative.toFixed(4)}` +
+        `\nNeutral: ${r.avgSentiment.neutral.toFixed(4)}` +
         `\n</sentiment_bucket>`
       );
 
-      let output = `Got ${result.numResults} sentiment bucket(s) (splitBy=${args.splitBy ?? "DAY"})\n`;
+      let output = `Got ${result.results.length} sentiment bucket(s) (splitBy=${args.splitBy ?? "DAY"})\n`;
       output += `<avg_sentiment_results>\n`;
       output += rows.join("\n\n");
       output += `\n</avg_sentiment_results>`;

--- a/worker/mcp/tools/search/stats-avg-sentiment.ts
+++ b/worker/mcp/tools/search/stats-avg-sentiment.ts
@@ -1,0 +1,63 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { Perigon, AvgSentimentStatDto, StatResult } from "../../../lib/perigon";
+import { ToolCallback, ToolDefinition } from "../types";
+import { statsFilterArgs, splitByEnum } from "../schemas/stats";
+import { toolResult, noResults } from "../utils/formatting";
+import { createErrorMessage } from "../utils/error-handling";
+
+export const avgSentimentArgs = statsFilterArgs.extend({
+  splitBy: splitByEnum.optional(),
+});
+
+export function getAvgSentiment(perigon: Perigon): ToolCallback {
+  return async (args: z.infer<typeof avgSentimentArgs>): Promise<CallToolResult> => {
+    try {
+      const result: StatResult<AvgSentimentStatDto> = await perigon.getAvgSentiment({
+        q: args.q,
+        from: args.from,
+        to: args.to,
+        source: args.source,
+        sourceGroup: args.sourceGroup,
+        category: args.category,
+        topic: args.topic,
+        language: args.language,
+        country: args.country,
+        personName: args.personName,
+        companyDomain: args.companyDomain,
+        companySymbol: args.companySymbol,
+        splitBy: args.splitBy,
+      });
+
+      if (!result.results || result.results.length === 0) return noResults;
+
+      const rows = result.results.map((r) =>
+        `<sentiment_bucket date="${r.pubDate ?? r.addDate}">` +
+        `\nPositive: ${r.positive}` +
+        `\nNegative: ${r.negative}` +
+        `\nNeutral: ${r.neutral}` +
+        `\n</sentiment_bucket>`
+      );
+
+      let output = `Got ${result.numResults} sentiment bucket(s) (splitBy=${args.splitBy ?? "DAY"})\n`;
+      output += `<avg_sentiment_results>\n`;
+      output += rows.join("\n\n");
+      output += `\n</avg_sentiment_results>`;
+
+      return toolResult(output);
+    } catch (error) {
+      console.error("Error in get_avg_sentiment:", error);
+      return toolResult(
+        `Error: Failed to retrieve average sentiment: ${await createErrorMessage(error)}`
+      );
+    }
+  };
+}
+
+export const avgSentimentTool: ToolDefinition = {
+  name: "get_avg_sentiment",
+  description:
+    "Get average sentiment scores (positive, negative, neutral) bucketed over time for articles matching the given filters. Use this when the user asks about sentiment trends, how tone of coverage has shifted, or wants a chart/table of sentiment over a period — NOT for reading sentiment on individual articles (use search_news_articles for that). Returns one sentiment record per time bucket with averaged positive, negative, and neutral scores. Use splitBy to control the interval (HOUR, DAY, WEEK, MONTH, or NONE for a single aggregate across the whole date range). Supports the same article filters as search_news_articles.",
+  parameters: avgSentimentArgs,
+  createHandler: (perigon: Perigon) => getAvgSentiment(perigon),
+};

--- a/worker/mcp/tools/search/stats-top-companies.ts
+++ b/worker/mcp/tools/search/stats-top-companies.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { Perigon, TableSearchResult, EntitySpike } from "../../../lib/perigon";
+import { Perigon, SpikeResult, CompanySpike } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
 import { statsFilterArgs } from "../schemas/stats";
 import { toolResult, noResults } from "../utils/formatting";
@@ -9,6 +9,10 @@ import { createErrorMessage } from "../utils/error-handling";
 function parseTime(str: string) {
   if (str === "") return undefined;
   return new Date(str);
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }
 
 export const topCompaniesArgs = statsFilterArgs.extend({
@@ -59,7 +63,7 @@ export const topCompaniesArgs = statsFilterArgs.extend({
 export function getTopCompanies(perigon: Perigon): ToolCallback {
   return async (args: z.infer<typeof topCompaniesArgs>): Promise<CallToolResult> => {
     try {
-      const result: TableSearchResult<EntitySpike> = await perigon.getTopCompanies({
+      const result: SpikeResult<CompanySpike> = await perigon.getTopCompanies({
         q: args.q,
         from: args.from,
         to: args.to,
@@ -80,13 +84,24 @@ export function getTopCompanies(perigon: Perigon): ToolCallback {
         size: args.size,
       });
 
-      if (!result.results || result.results.length === 0) return noResults;
+      if (!result.data || result.data.length === 0) return noResults;
 
-      const rows = result.results.map((c, i) =>
-        `<company rank="${i + 1}" name="${c.name}" current_count="${c.currentCount}" baseline_count="${c.baselineCount}" spike_score="${c.spikeScore?.toFixed(2) ?? "N/A"}" />`
-      );
+      const rows = result.data.map((c, i) => {
+        const name = escapeAttr(c.company?.name ?? c.wikidataId);
+        const domain = escapeAttr((c.company?.domains ?? [])[0] ?? "");
+        const ticker = escapeAttr((c.company?.symbols ?? [])[0]?.symbol ?? "");
+        const industry = escapeAttr(c.company?.industry ?? "");
+        const sector = escapeAttr(c.company?.sector ?? "");
+        return (
+          `<company rank="${i + 1}" id="${c.wikidataId}" name="${name}" ` +
+          `domain="${domain}" ticker="${ticker}" industry="${industry}" sector="${sector}" ` +
+          `current_mentions="${c.currentMentions}" baseline_mentions="${c.baselineMentions}" ` +
+          `current_rate_per_day="${c.currentRatePerDay.toFixed(2)}" baseline_rate_per_day="${c.baselineRatePerDay.toFixed(2)}" ` +
+          `spike_score="${c.spikeScore.toFixed(2)}" />`
+        );
+      });
 
-      let output = `Got ${result.numResults} companies with highest spike scores\n`;
+      let output = `Got ${result.total} companies with highest spike scores\n`;
       output += `<top_companies_results>\n`;
       output += rows.join("\n");
       output += `\n</top_companies_results>`;

--- a/worker/mcp/tools/search/stats-top-companies.ts
+++ b/worker/mcp/tools/search/stats-top-companies.ts
@@ -1,0 +1,110 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { Perigon, TableSearchResult, EntitySpike } from "../../../lib/perigon";
+import { ToolCallback, ToolDefinition } from "../types";
+import { statsFilterArgs } from "../schemas/stats";
+import { toolResult, noResults } from "../utils/formatting";
+import { createErrorMessage } from "../utils/error-handling";
+
+function parseTime(str: string) {
+  if (str === "") return undefined;
+  return new Date(str);
+}
+
+export const topCompaniesArgs = statsFilterArgs.extend({
+  currentFrom: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "Start of the current window for spike detection. Default: 3 days ago. ISO 8601 or yyyy-mm-dd."
+    ),
+  currentTo: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "End of the current window for spike detection. Default: now. ISO 8601 or yyyy-mm-dd."
+    ),
+  baselineFrom: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "Start of the baseline window for spike detection. Default: 30 days ago. ISO 8601 or yyyy-mm-dd."
+    ),
+  baselineTo: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "End of the baseline window for spike detection. Default: 3 days ago. ISO 8601 or yyyy-mm-dd."
+    ),
+  normalizeByDay: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      "If true, compares daily mention rates between current and baseline windows (adjusts for window length differences). Default: true."
+    ),
+  size: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(10)
+    .describe("Number of top companies to return (1–100). Default: 10."),
+});
+
+export function getTopCompanies(perigon: Perigon): ToolCallback {
+  return async (args: z.infer<typeof topCompaniesArgs>): Promise<CallToolResult> => {
+    try {
+      const result: TableSearchResult<EntitySpike> = await perigon.getTopCompanies({
+        q: args.q,
+        from: args.from,
+        to: args.to,
+        source: args.source,
+        sourceGroup: args.sourceGroup,
+        category: args.category,
+        topic: args.topic,
+        language: args.language,
+        country: args.country,
+        personName: args.personName,
+        companyDomain: args.companyDomain,
+        companySymbol: args.companySymbol,
+        currentFrom: args.currentFrom,
+        currentTo: args.currentTo,
+        baselineFrom: args.baselineFrom,
+        baselineTo: args.baselineTo,
+        normalizeByDay: args.normalizeByDay,
+        size: args.size,
+      });
+
+      if (!result.results || result.results.length === 0) return noResults;
+
+      const rows = result.results.map((c, i) =>
+        `<company rank="${i + 1}" name="${c.name}" current_count="${c.currentCount}" baseline_count="${c.baselineCount}" spike_score="${c.spikeScore?.toFixed(2) ?? "N/A"}" />`
+      );
+
+      let output = `Got ${result.numResults} companies with highest spike scores\n`;
+      output += `<top_companies_results>\n`;
+      output += rows.join("\n");
+      output += `\n</top_companies_results>`;
+
+      return toolResult(output);
+    } catch (error) {
+      console.error("Error in get_top_companies:", error);
+      return toolResult(
+        `Error: Failed to retrieve top companies: ${await createErrorMessage(error)}`
+      );
+    }
+  };
+}
+
+export const topCompaniesTool: ToolDefinition = {
+  name: "get_top_companies",
+  description:
+    "Get the companies whose news coverage is spiking — mentioned significantly more in a recent window than a prior baseline period. Use this when the user asks 'which companies are trending?', 'which companies are getting more coverage than usual?', or 'what companies are suddenly in the news?' — NOT for simple most-mentioned frequency (use get_top_entities for that). Returns a ranked list with current mention count, baseline count, and a spike score (higher = bigger relative increase). The comparison window defaults to last 3 days vs. last 30 days; override with currentFrom/To and baselineFrom/To. Supports all standard article filters to scope the analysis to a specific topic, source, or date range.",
+  parameters: topCompaniesArgs,
+  createHandler: (perigon: Perigon) => getTopCompanies(perigon),
+};

--- a/worker/mcp/tools/search/stats-top-entities.ts
+++ b/worker/mcp/tools/search/stats-top-entities.ts
@@ -1,16 +1,17 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { Perigon, TopEntitiesDto } from "../../../lib/perigon";
+import { Perigon, TopEntitiesDto, TopEntityItem } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
 import { statsFilterArgs } from "../schemas/stats";
 import { toolResult, noResults } from "../utils/formatting";
 import { createErrorMessage } from "../utils/error-handling";
 
+const ENTITY_TYPES = ["topics", "people", "companies", "cities", "journalists", "sources"] as const;
+type EntityType = (typeof ENTITY_TYPES)[number];
+
 export const topEntitiesArgs = statsFilterArgs.extend({
   entity: z
-    .array(
-      z.enum(["topics", "people", "companies", "cities", "journalists", "sources"])
-    )
+    .array(z.enum(ENTITY_TYPES))
     .optional()
     .default(["topics", "people", "companies"])
     .describe(
@@ -18,9 +19,20 @@ export const topEntitiesArgs = statsFilterArgs.extend({
     ),
 });
 
+const TOTAL_KEY: Record<EntityType, keyof TopEntitiesDto> = {
+  topics: "totalTopics",
+  people: "totalPeople",
+  companies: "totalCompanies",
+  cities: "totalCities",
+  journalists: "totalJournalists",
+  sources: "totalSources",
+};
+
 export function getTopEntities(perigon: Perigon): ToolCallback {
   return async (args: z.infer<typeof topEntitiesArgs>): Promise<CallToolResult> => {
     try {
+      const requested = args.entity ?? ["topics", "people", "companies"];
+
       const result: TopEntitiesDto = await perigon.getTopEntities({
         q: args.q,
         from: args.from,
@@ -34,21 +46,25 @@ export function getTopEntities(perigon: Perigon): ToolCallback {
         personName: args.personName,
         companyDomain: args.companyDomain,
         companySymbol: args.companySymbol,
-        entity: args.entity,
+        entity: requested,
       });
 
-      const hasResults = Object.values(result).some(
-        (v) => Array.isArray(v) && v.length > 0
-      );
+      const hasResults = requested.some((t) => {
+        const items = result[t] as TopEntityItem[] | undefined;
+        return Array.isArray(items) && items.length > 0;
+      });
       if (!hasResults) return noResults;
 
-      let output = `<top_entities>\n`;
+      let output = `<top_entities total_articles="${result.totalArticles ?? 0}">\n`;
 
-      for (const entityType of (args.entity ?? ["topics", "people", "companies"])) {
-        const items = result[entityType];
+      for (const entityType of requested) {
+        const items = result[entityType] as TopEntityItem[] | undefined;
         if (!Array.isArray(items) || items.length === 0) continue;
-        output += `\n<${entityType}>\n`;
-        output += JSON.stringify(items, null, 2);
+        const total = result[TOTAL_KEY[entityType]] as number | undefined;
+        output += `\n<${entityType} total="${total ?? items.length}">\n`;
+        output += items
+          .map((it, i) => `  <item rank="${i + 1}" key="${it.key}" count="${it.count}" />`)
+          .join("\n");
         output += `\n</${entityType}>\n`;
       }
 

--- a/worker/mcp/tools/search/stats-top-entities.ts
+++ b/worker/mcp/tools/search/stats-top-entities.ts
@@ -1,0 +1,73 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { Perigon, TopEntitiesDto } from "../../../lib/perigon";
+import { ToolCallback, ToolDefinition } from "../types";
+import { statsFilterArgs } from "../schemas/stats";
+import { toolResult, noResults } from "../utils/formatting";
+import { createErrorMessage } from "../utils/error-handling";
+
+export const topEntitiesArgs = statsFilterArgs.extend({
+  entity: z
+    .array(
+      z.enum(["topics", "people", "companies", "cities", "journalists", "sources"])
+    )
+    .optional()
+    .default(["topics", "people", "companies"])
+    .describe(
+      "Which entity types to return. Options: topics, people, companies, cities, journalists, sources. Defaults to topics, people, and companies."
+    ),
+});
+
+export function getTopEntities(perigon: Perigon): ToolCallback {
+  return async (args: z.infer<typeof topEntitiesArgs>): Promise<CallToolResult> => {
+    try {
+      const result: TopEntitiesDto = await perigon.getTopEntities({
+        q: args.q,
+        from: args.from,
+        to: args.to,
+        source: args.source,
+        sourceGroup: args.sourceGroup,
+        category: args.category,
+        topic: args.topic,
+        language: args.language,
+        country: args.country,
+        personName: args.personName,
+        companyDomain: args.companyDomain,
+        companySymbol: args.companySymbol,
+        entity: args.entity,
+      });
+
+      const hasResults = Object.values(result).some(
+        (v) => Array.isArray(v) && v.length > 0
+      );
+      if (!hasResults) return noResults;
+
+      let output = `<top_entities>\n`;
+
+      for (const entityType of (args.entity ?? ["topics", "people", "companies"])) {
+        const items = result[entityType];
+        if (!Array.isArray(items) || items.length === 0) continue;
+        output += `\n<${entityType}>\n`;
+        output += JSON.stringify(items, null, 2);
+        output += `\n</${entityType}>\n`;
+      }
+
+      output += `</top_entities>`;
+
+      return toolResult(output);
+    } catch (error) {
+      console.error("Error in get_top_entities:", error);
+      return toolResult(
+        `Error: Failed to retrieve top entities: ${await createErrorMessage(error)}`
+      );
+    }
+  };
+}
+
+export const topEntitiesTool: ToolDefinition = {
+  name: "get_top_entities",
+  description:
+    "Get the most frequently mentioned entities in articles matching the given filters, ranked by raw mention count. Use this when the user asks 'what topics/people/companies are most covered?' or 'who appears most in X news?' — i.e., questions about overall mention frequency within a fixed window. Do NOT use this for detecting sudden spikes or trending entities; use get_top_people or get_top_companies for spike detection instead. Defaults to returning topics, people, and companies; use the entity parameter to request other types (cities, journalists, sources). Supports the same article filters as search_news_articles.",
+  parameters: topEntitiesArgs,
+  createHandler: (perigon: Perigon) => getTopEntities(perigon),
+};

--- a/worker/mcp/tools/search/stats-top-people.ts
+++ b/worker/mcp/tools/search/stats-top-people.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { Perigon, TableSearchResult, EntitySpike } from "../../../lib/perigon";
+import { Perigon, SpikeResult, PersonSpike } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
 import { statsFilterArgs } from "../schemas/stats";
 import { toolResult, noResults } from "../utils/formatting";
@@ -9,6 +9,10 @@ import { createErrorMessage } from "../utils/error-handling";
 function parseTime(str: string) {
   if (str === "") return undefined;
   return new Date(str);
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
 }
 
 export const topPeopleArgs = statsFilterArgs.extend({
@@ -59,7 +63,7 @@ export const topPeopleArgs = statsFilterArgs.extend({
 export function getTopPeople(perigon: Perigon): ToolCallback {
   return async (args: z.infer<typeof topPeopleArgs>): Promise<CallToolResult> => {
     try {
-      const result: TableSearchResult<EntitySpike> = await perigon.getTopPeople({
+      const result: SpikeResult<PersonSpike> = await perigon.getTopPeople({
         q: args.q,
         from: args.from,
         to: args.to,
@@ -80,13 +84,23 @@ export function getTopPeople(perigon: Perigon): ToolCallback {
         size: args.size,
       });
 
-      if (!result.results || result.results.length === 0) return noResults;
+      if (!result.data || result.data.length === 0) return noResults;
 
-      const rows = result.results.map((p, i) =>
-        `<person rank="${i + 1}" name="${p.name}" current_count="${p.currentCount}" baseline_count="${p.baselineCount}" spike_score="${p.spikeScore?.toFixed(2) ?? "N/A"}" />`
-      );
+      const rows = result.data.map((p, i) => {
+        const name = escapeAttr(p.person?.name ?? p.wikidataId);
+        const description = escapeAttr(p.person?.description ?? "");
+        const occupation = escapeAttr(
+          (p.person?.occupation ?? []).map((o) => o.label).join(", ")
+        );
+        return (
+          `<person rank="${i + 1}" wikidata_id="${p.wikidataId}" name="${name}" ` +
+          `current_mentions="${p.currentMentions}" baseline_mentions="${p.baselineMentions}" ` +
+          `current_rate_per_day="${p.currentRatePerDay.toFixed(2)}" baseline_rate_per_day="${p.baselineRatePerDay.toFixed(2)}" ` +
+          `spike_score="${p.spikeScore.toFixed(2)}" occupation="${occupation}" description="${description}" />`
+        );
+      });
 
-      let output = `Got ${result.numResults} people with highest spike scores\n`;
+      let output = `Got ${result.total} people with highest spike scores\n`;
       output += `<top_people_results>\n`;
       output += rows.join("\n");
       output += `\n</top_people_results>`;

--- a/worker/mcp/tools/search/stats-top-people.ts
+++ b/worker/mcp/tools/search/stats-top-people.ts
@@ -1,0 +1,110 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { Perigon, TableSearchResult, EntitySpike } from "../../../lib/perigon";
+import { ToolCallback, ToolDefinition } from "../types";
+import { statsFilterArgs } from "../schemas/stats";
+import { toolResult, noResults } from "../utils/formatting";
+import { createErrorMessage } from "../utils/error-handling";
+
+function parseTime(str: string) {
+  if (str === "") return undefined;
+  return new Date(str);
+}
+
+export const topPeopleArgs = statsFilterArgs.extend({
+  currentFrom: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "Start of the current window for spike detection. Default: 3 days ago. ISO 8601 or yyyy-mm-dd."
+    ),
+  currentTo: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "End of the current window for spike detection. Default: now. ISO 8601 or yyyy-mm-dd."
+    ),
+  baselineFrom: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "Start of the baseline window for spike detection. Default: 30 days ago. ISO 8601 or yyyy-mm-dd."
+    ),
+  baselineTo: z
+    .string()
+    .transform(parseTime)
+    .optional()
+    .describe(
+      "End of the baseline window for spike detection. Default: 3 days ago. ISO 8601 or yyyy-mm-dd."
+    ),
+  normalizeByDay: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      "If true, compares daily mention rates between current and baseline windows (adjusts for window length differences). Default: true."
+    ),
+  size: z
+    .number()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(10)
+    .describe("Number of top people to return (1–100). Default: 10."),
+});
+
+export function getTopPeople(perigon: Perigon): ToolCallback {
+  return async (args: z.infer<typeof topPeopleArgs>): Promise<CallToolResult> => {
+    try {
+      const result: TableSearchResult<EntitySpike> = await perigon.getTopPeople({
+        q: args.q,
+        from: args.from,
+        to: args.to,
+        source: args.source,
+        sourceGroup: args.sourceGroup,
+        category: args.category,
+        topic: args.topic,
+        language: args.language,
+        country: args.country,
+        personName: args.personName,
+        companyDomain: args.companyDomain,
+        companySymbol: args.companySymbol,
+        currentFrom: args.currentFrom,
+        currentTo: args.currentTo,
+        baselineFrom: args.baselineFrom,
+        baselineTo: args.baselineTo,
+        normalizeByDay: args.normalizeByDay,
+        size: args.size,
+      });
+
+      if (!result.results || result.results.length === 0) return noResults;
+
+      const rows = result.results.map((p, i) =>
+        `<person rank="${i + 1}" name="${p.name}" current_count="${p.currentCount}" baseline_count="${p.baselineCount}" spike_score="${p.spikeScore?.toFixed(2) ?? "N/A"}" />`
+      );
+
+      let output = `Got ${result.numResults} people with highest spike scores\n`;
+      output += `<top_people_results>\n`;
+      output += rows.join("\n");
+      output += `\n</top_people_results>`;
+
+      return toolResult(output);
+    } catch (error) {
+      console.error("Error in get_top_people:", error);
+      return toolResult(
+        `Error: Failed to retrieve top people: ${await createErrorMessage(error)}`
+      );
+    }
+  };
+}
+
+export const topPeopleTool: ToolDefinition = {
+  name: "get_top_people",
+  description:
+    "Get the people whose news coverage is spiking — mentioned significantly more in a recent window than a prior baseline period. Use this when the user asks 'who is trending?', 'who suddenly got a lot of coverage?', or 'which people are in the news more than usual?' — NOT for simple most-mentioned frequency (use get_top_entities for that). Returns a ranked list with current mention count, baseline count, and a spike score (higher = bigger relative increase). The comparison window defaults to last 3 days vs. last 30 days; override with currentFrom/To and baselineFrom/To. Supports all standard article filters to scope the analysis to a specific topic, source, or date range.",
+  parameters: topPeopleArgs,
+  createHandler: (perigon: Perigon) => getTopPeople(perigon),
+};

--- a/worker/mcp/tools/use-cases/person-news.ts
+++ b/worker/mcp/tools/use-cases/person-news.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { Perigon } from "../../../lib/perigon";
 import { ToolCallback, ToolDefinition } from "../types";
-import { toolResult } from "../utils/formatting";
+import { toolResult, formatLabelList } from "../utils/formatting";
 import { createErrorMessage } from "../utils/error-handling";
 
 /**
@@ -77,10 +77,10 @@ export function getPersonNews(perigon: Perigon): ToolCallback {
         if (personResult.numResults > 0) {
           const person = personResult.results[0];
           personInfo = `\n<person-context>
-Name: ${person.name}
-Occupation: ${person.occupation || 'N/A'}
-Position: ${person.position || 'N/A'}
-Description: ${person.description || 'N/A'}
+Name: ${person.name ?? 'N/A'}
+Occupation: ${formatLabelList(person.occupation)}
+Position: ${formatLabelList(person.position)}
+Description: ${person.description ?? 'N/A'}
 </person-context>\n`;
         }
       } catch (error) {

--- a/worker/mcp/tools/utils/error-handling.ts
+++ b/worker/mcp/tools/utils/error-handling.ts
@@ -3,6 +3,42 @@ import {
   FetchError,
   RequiredError,
 } from "@goperigon/perigon-ts";
+import { HttpError } from "../../../types/types";
+
+/**
+ * Try to extract a human-readable message from an api.perigon.io error body.
+ * The API typically returns JSON like `{"timestamp":...,"status":500,"message":"...","error":"...","path":"..."}`,
+ * but on some 5xxs it returns a plain string such as "internal error; reference = abc123".
+ * We preserve any reference id since that's what the Perigon team uses to debug.
+ */
+function extractApiErrorMessage(status: number, body: string): string {
+  if (!body) return `Request failed with status: ${status}`;
+
+  const trimmed = body.trim();
+  // JSON body: prefer message > error > raw
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as {
+        message?: string;
+        error?: string;
+        path?: string;
+      };
+      const parts = [parsed.message, parsed.error].filter(
+        (p): p is string => typeof p === "string" && p.length > 0
+      );
+      if (parts.length > 0) {
+        return `${parts.join(" — ")} (status ${status}${
+          parsed.path ? `, path ${parsed.path}` : ""
+        })`;
+      }
+    } catch {
+      // fall through to raw body
+    }
+  }
+
+  // Plain-text body — surface as-is so trace refs survive
+  return `${trimmed} (status ${status})`;
+}
 
 /**
  * Create a standardized error message from various error types
@@ -11,9 +47,12 @@ import {
  */
 export async function createErrorMessage(error: any): Promise<string> {
   let msg: string | undefined;
-  
-  if (error instanceof ResponseError) {
-    msg = await error.response.text();
+
+  if (error instanceof HttpError) {
+    msg = extractApiErrorMessage(error.statusCode, error.responseBody);
+  } else if (error instanceof ResponseError) {
+    const body = await error.response.text().catch(() => "");
+    msg = extractApiErrorMessage(error.response.status, body);
   } else if (error instanceof FetchError) {
     msg = error.cause.message;
   } else if (error instanceof RequiredError) {
@@ -23,6 +62,6 @@ export async function createErrorMessage(error: any): Promise<string> {
   } else {
     msg = String(error);
   }
-  
+
   return msg || "Unknown error occurred";
 }

--- a/worker/mcp/tools/utils/formatting.ts
+++ b/worker/mcp/tools/utils/formatting.ts
@@ -33,3 +33,48 @@ export function createPaginationHeader(
   const totalPages = Math.ceil(total / size);
   return `Got ${total} ${itemType} (page ${page} of ${totalPages - 1})`;
 }
+
+/**
+ * Format an array of `WikidataLabelHolder`-like objects (or strings) into a
+ * human-readable comma-separated list of labels. Returns "N/A" when the
+ * collection is empty/null/undefined so the LLM never sees `[object Object]`.
+ */
+export function formatLabelList(
+  items:
+    | Array<{ label?: string | null } | string | null | undefined>
+    | null
+    | undefined,
+  fallback = "N/A",
+): string {
+  if (!items || items.length === 0) return fallback;
+  const labels = items
+    .map((item) => {
+      if (item == null) return null;
+      if (typeof item === "string") return item;
+      return item.label ?? null;
+    })
+    .filter((label): label is string => typeof label === "string" && label.length > 0);
+  return labels.length > 0 ? labels.join(", ") : fallback;
+}
+
+/**
+ * Pull the `label` out of a single `WikidataLabelHolder`-like object.
+ */
+export function formatLabel(
+  holder: { label?: string | null } | null | undefined,
+  fallback = "N/A",
+): string {
+  return holder?.label?.trim() || fallback;
+}
+
+/**
+ * Render a `WikidataDateHolder` (`{time, precision}`) as an ISO date string.
+ */
+export function formatWikidataDate(
+  holder: { time?: string | null; precision?: string | null } | null | undefined,
+  fallback = "N/A",
+): string {
+  if (!holder?.time) return fallback;
+  // Time is ISO 8601, but we usually only care about the date portion
+  return holder.time.split("T")[0] || holder.time;
+}


### PR DESCRIPTION
## Summary

- Add 5 new MCP tools backed by the `/v1/stats/*` Perigon API endpoints:
  - `get_avg_sentiment` — average sentiment (positive/negative/neutral) over time, with optional `splitBy` (HOUR/DAY/WEEK/MONTH)
  - `get_article_counts` — article publication volume over time with optional time-series splitting
  - `get_top_entities` — most-mentioned topics, people, companies, cities, journalists, sources within a filter window
  - `get_top_people` — people whose coverage is spiking vs. a baseline period (spike score ranked)
  - `get_top_companies` — companies whose coverage is spiking vs. a baseline period (spike score ranked)
- Add shared `statsFilterArgs` Zod schema covering all standard article filters (q, from/to, source, category, topic, language, country, personName, companyDomain, companySymbol)
- Add `buildStatsFilters` private helper on the `Perigon` class to avoid repetition across the 5 new API methods
- Fix `tsconfig.json` to remove unused `worker-configuration.d.ts` and `vite/client` type entries

## Test plan

- [ ] Run `bun run mcp` and verify the 5 new tools appear in the MCP inspector
- [ ] Test `get_top_people` and `get_top_companies` with default params — should return spike-ranked results
- [ ] Test `get_top_entities` with `entity: ["topics", "companies"]`
- [ ] Test `get_avg_sentiment` with `splitBy: "DAY"` over a date range
- [ ] Test `get_article_counts` with a keyword query

Made with [Cursor](https://cursor.com)