### PR TITLE
Add insights topic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,14 @@ Signal Insights tools use an explicit workspace handle (per [SEP-2567](https://m
 
 | Tool | Type | Description |
 |------|------|-------------|
-| `signal_insights_create_workspace` | Setup | Create a workspace for the conversation. Must be called first. |
-| `signal_insights_search_signals` | Read | Search signals by name or monitoring objective. |
-| `signal_insights_read_signal` | Read | Get signal metadata (schema, event types, counts). |
-| `signal_insights_export_events` | Data | Export signal events to S3 with optional filters/aggregations. Returns a preview and file path. |
+| `signal_insights_create_workspace` | Setup | Create a workspace for the conversation. Must be called first for sandbox tools. |
+| `signal_insights_search_signals` | Read | Search signals by name or objective; optional `classificationTypes` filter. |
+| `signal_insights_read_signal` | Read | Get signal metadata (classification, schema or newsletter counts). |
+| `signal_insights_list_newsletters` | Read | List newsletters for a TOPIC signal (title + excerpt). |
+| `signal_insights_read_newsletter` | Read | Fetch full newsletter content as markdown. |
+| `signal_insights_export_events` | Data | Export events to S3 (EVENT/MENTIONS only). Returns a preview and file path. |
 | `signal_insights_execute_code` | Sandbox | Execute Python in a persistent IPython kernel. pandas, numpy, matplotlib and more pre-installed. |
+| `signal_insights_preview_chart` | Sandbox | Render charts in the interactive chart viewer. |
 | `signal_insights_shell` | Sandbox | Run bash commands in the sandbox. |
 | `signal_insights_list_files` | Files | List files in the sandbox workspace. |
 | `signal_insights_read_file` | Files | Read a file from the workspace. |
@@ -184,7 +187,7 @@ Signal Insights tools use an explicit workspace handle (per [SEP-2567](https://m
 {
   "mcpServers": {
     "perigon": {
-      "url": "https://mcp.perigon.io/v1/mcp?tools=signal_insights_create_workspace,signal_insights_search_signals,signal_insights_read_signal,signal_insights_export_events,signal_insights_execute_code,signal_insights_shell,signal_insights_list_files,signal_insights_read_file,signal_insights_write_file,signal_insights_grep,signal_insights_str_replace",
+      "url": "https://mcp.perigon.io/v1/mcp?tools=signal_insights_create_workspace,signal_insights_search_signals,signal_insights_read_signal,signal_insights_list_newsletters,signal_insights_read_newsletter,signal_insights_export_events,signal_insights_execute_code,signal_insights_preview_chart,signal_insights_shell,signal_insights_list_files,signal_insights_read_file,signal_insights_write_file,signal_insights_grep,signal_insights_str_replace",
       "type": "http",
       "headers": {
         "Authorization": "Bearer YOUR_PERIGON_API_KEY"

--- a/src/lib/mcp-tools.ts
+++ b/src/lib/mcp-tools.ts
@@ -173,14 +173,28 @@ export const MCP_TOOLS: McpToolMeta[] = [
     name: "signal_insights_read_signal",
     label: "Read Signal",
     description:
-      "Get full signal metadata including data schema, available event types, and event count. Use before exporting to understand available fields.",
+      "Get full signal metadata including classificationType, schema (EVENT/MENTIONS), or newsletterCount (TOPIC).",
+    category: "signal-insights",
+  },
+  {
+    name: "signal_insights_list_newsletters",
+    label: "List Newsletters",
+    description:
+      "List newsletters/briefings for a TOPIC signal with title and short excerpt. EVENT/MENTIONS signals will error.",
+    category: "signal-insights",
+  },
+  {
+    name: "signal_insights_read_newsletter",
+    label: "Read Newsletter",
+    description:
+      "Fetch a full newsletter by UUID as markdown (YAML frontmatter + body) for context or analysis.",
     category: "signal-insights",
   },
   {
     name: "signal_insights_export_events",
     label: "Export Signal Events",
     description:
-      "Export signal events using a structured query API with filters, aggregations, and ordering. Returns a data preview and an S3 file path.",
+      "Export signal events using a structured query API with filters, aggregations, and ordering. EVENT/MENTIONS only.",
     category: "signal-insights",
   },
   {

--- a/test/unit/mcp/tools-registry.test.ts
+++ b/test/unit/mcp/tools-registry.test.ts
@@ -30,6 +30,8 @@ const EXPECTED_TOOL_NAMES = [
   "signal_insights_create_workspace",
   "signal_insights_search_signals",
   "signal_insights_read_signal",
+  "signal_insights_list_newsletters",
+  "signal_insights_read_newsletter",
   "signal_insights_export_events",
   "signal_insights_execute_code",
   "signal_insights_preview_chart",
@@ -46,7 +48,7 @@ describe("TOOL_DEFINITIONS", () => {
     const actual = Object.keys(TOOL_DEFINITIONS).sort();
     const expected = [...EXPECTED_TOOL_NAMES].sort();
     expect(actual).toEqual(expected);
-    expect(actual.length).toBe(32);
+    expect(actual.length).toBe(34);
   });
 
   test("each tool exposes name, description, parameters, and createHandler", () => {

--- a/worker/lib/format-newsletter.ts
+++ b/worker/lib/format-newsletter.ts
@@ -1,0 +1,37 @@
+/**
+ * Format a newsletter JSON payload as model-readable markdown with YAML frontmatter.
+ * Mirrors pokey formatNewsletterMarkdown.
+ */
+export function formatNewsletterMarkdown(newsletter: {
+  uuid: string;
+  signalUuid: string;
+  signalName: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}): string {
+  const frontmatter = [
+    "---",
+    `uuid: ${newsletter.uuid}`,
+    `signalUuid: ${newsletter.signalUuid}`,
+    `signalName: ${escapeYamlScalar(newsletter.signalName)}`,
+    `title: ${escapeYamlScalar(newsletter.title)}`,
+    `createdAt: ${newsletter.createdAt}`,
+    `updatedAt: ${newsletter.updatedAt}`,
+    "---",
+  ].join("\n");
+
+  return `${frontmatter}\n\n# ${newsletter.title}\n\n${newsletter.content}`;
+}
+
+function escapeYamlScalar(value: string): string {
+  if (
+    /[:#{}[\],&*?|>!%@`]/.test(value) ||
+    value.includes("\n") ||
+    value.includes('"')
+  ) {
+    return JSON.stringify(value);
+  }
+  return value;
+}

--- a/worker/lib/insights-api-client.ts
+++ b/worker/lib/insights-api-client.ts
@@ -1,4 +1,5 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { formatNewsletterMarkdown } from "./format-newsletter";
 
 const BASE_URL = "https://api.perigon.io/v1/signal/insights/mcp";
 
@@ -6,7 +7,7 @@ const BASE_URL = "https://api.perigon.io/v1/signal/insights/mcp";
  * Thin HTTP client for the Signal Insights read-only endpoints on
  * api.perigon.io (authenticated by Perigon API key).
  *
- * These endpoints are served by the InsightsApiKeyController in the
+ * These endpoints are served by the InsightsController (MCP alias) in the
  * business-api-server and require the SIGNAL_INSIGHTS permission scope.
  */
 export class InsightsApiClient {
@@ -23,6 +24,7 @@ export class InsightsApiClient {
     query?: string;
     page?: number;
     limit?: number;
+    classificationTypes?: Array<"EVENT" | "MENTIONS" | "TOPIC">;
   }): Promise<CallToolResult> {
     const url = new URL(`${BASE_URL}/search`);
     if (args.query) url.searchParams.set("query", args.query);
@@ -30,6 +32,11 @@ export class InsightsApiClient {
       url.searchParams.set("page", String(args.page));
     if (args.limit !== undefined)
       url.searchParams.set("limit", String(args.limit));
+    if (args.classificationTypes) {
+      for (const t of args.classificationTypes) {
+        url.searchParams.append("classificationTypes", t);
+      }
+    }
 
     const res = await fetch(url.toString(), {
       headers: this.headers,
@@ -69,5 +76,79 @@ export class InsightsApiClient {
 
     const data = await res.json();
     return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  async listNewsletters(args: {
+    signalUuid: string;
+    page?: number;
+    limit?: number;
+  }): Promise<CallToolResult> {
+    const url = new URL(`${BASE_URL}/${args.signalUuid}/newsletters`);
+    if (args.page !== undefined)
+      url.searchParams.set("page", String(args.page));
+    if (args.limit !== undefined)
+      url.searchParams.set("limit", String(args.limit));
+
+    const res = await fetch(url.toString(), {
+      headers: this.headers,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `List newsletters failed (${res.status}): ${body}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const data = await res.json();
+    return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  }
+
+  async readNewsletter(newsletterUuid: string): Promise<CallToolResult> {
+    const res = await fetch(`${BASE_URL}/newsletters/${newsletterUuid}`, {
+      headers: this.headers,
+      signal: AbortSignal.timeout(this.timeoutMs),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Read newsletter failed (${res.status}): ${body}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const envelope = (await res.json()) as {
+      data?: {
+        uuid: string;
+        signalUuid: string;
+        signalName: string;
+        title: string;
+        content: string;
+        createdAt: string;
+        updatedAt: string;
+      };
+    };
+    const newsletter = envelope.data;
+    if (!newsletter) {
+      return {
+        content: [{ type: "text", text: "Read newsletter failed: empty body" }],
+        isError: true,
+      };
+    }
+
+    return {
+      content: [{ type: "text", text: formatNewsletterMarkdown(newsletter) }],
+    };
   }
 }

--- a/worker/mcp/instructions.ts
+++ b/worker/mcp/instructions.ts
@@ -16,6 +16,8 @@ import { summarizeTool } from "./tools/search/summarize";
 import { createWorkspaceTool } from "./tools/signals/create-workspace";
 import { searchSignalsTool } from "./tools/signals/search-signals";
 import { readSignalTool } from "./tools/signals/read-signal";
+import { listNewslettersTool } from "./tools/signals/list-newsletters";
+import { readNewsletterTool } from "./tools/signals/read-newsletter";
 import { exportEventsTool } from "./tools/signals/export-events";
 import { executeCodeTool } from "./tools/signals/execute-code";
 import { previewChartTool } from "./tools/signals/preview-chart";
@@ -59,32 +61,43 @@ Tips:
 
 ## Signal Insights
 
-Analyze structured event data from Perigon's monitoring signals (funding rounds, layoffs, M&A, product launches, cybersecurity incidents, etc.). Requires a workspace.
+Analyze Perigon monitoring signals. Requires a workspace for sandbox tools (export, code, charts).
 
 ### What are signals?
-Signals are a way to monitor news media. Users can define arbitrary monitoring goals, and Perigon's processing pipeline uses them to produce a realtime stream of events, derived from news data and other sources.
-Each event in the stream has a structured schema, defined by the user.
+Signals monitor news media against a user-defined goal. Classification types:
 
-### Setup (required once per conversation)
-1. Call \`${createWorkspaceTool.name}\` — returns a workspace ID needed by all subsequent tools.
+| Type | Output | Data tools |
+|------|--------|------------|
+| EVENT | Structured realtime events with a user-defined schema | \`${readSignalTool.name}\` → \`${exportEventsTool.name}\` |
+| MENTIONS | Structured mention events | same as EVENT |
+| TOPIC | Scheduled briefings / newsletters (prose) | \`${readSignalTool.name}\` → \`${listNewslettersTool.name}\` → \`${readNewsletterTool.name}\` |
+
+Do not confuse signal classification TOPIC with \`${topicsTool.name}\` (Perigon news taxonomy).
+
+### Setup (required once per conversation for sandbox tools)
+1. Call \`${createWorkspaceTool.name}\` — returns a workspace ID needed by export/code/file tools.
 2. NEVER invent workspace IDs. Always use the one returned by \`${createWorkspaceTool.name}\`.
 
 ### Discovery
-3. \`${searchSignalsTool.name}\` — find signals by name or objective. Omit query to list all.
-4. \`${readSignalTool.name}\` — get a signal's full metadata, data schema, event types, and count. Always call this before \`${exportEventsTool.name}\` to understand available fields.
+3. \`${searchSignalsTool.name}\` — find signals by name or objective. Optional \`classificationTypes\` filter (EVENT, MENTIONS, TOPIC). Omit query to list all.
+4. \`${readSignalTool.name}\` — metadata including classificationType and type-specific fields (schema for EVENT/MENTIONS; newsletterCount for TOPIC).
 
-### Data Export
-5. \`${exportEventsTool.name}\` — structured query API (not SQL). Specify signals, fields, filters, aggregations, ordering. Results are saved as JSONL files in the sandbox at ${DATA_DIR}/.
+### EVENT / MENTIONS data
+5. \`${exportEventsTool.name}\` — structured query API (not SQL). EVENT/MENTIONS only — TOPIC UUIDs will error. Results saved as JSONL at ${DATA_DIR}/.
    - Start with aggregations (COUNT, date_trunc) to understand data shape before fetching raw records.
-   - For complex analysis (window functions, pivots, joins across signals), fetch raw data first, then use \`${executeCodeTool.name}\` with pandas.
+   - For complex analysis, fetch raw data first, then use \`${executeCodeTool.name}\` with pandas.
+
+### TOPIC (briefing) data
+6. \`${listNewslettersTool.name}\` — titles + excerpts for a TOPIC signal.
+7. \`${readNewsletterTool.name}\` — full newsletter as markdown. Use for context or further analysis (including sandbox if useful).
 
 ### Analysis & Visualization
-6. \`${executeCodeTool.name}\` — run Python for data prep and analysis in a persistent Jupyter kernel. State persists between calls. Pre-installed: pandas, numpy, matplotlib, seaborn, scipy, scikit-learn, openpyxl, jinja2.
+8. \`${executeCodeTool.name}\` — run Python for data prep and analysis in a persistent Jupyter kernel. State persists between calls. Pre-installed: pandas, numpy, matplotlib, seaborn, scipy, scikit-learn, openpyxl, jinja2.
    - Read exported data: \`pd.read_json("${DATA_DIR}/<file>.jsonl", lines=True)\`
    - The kernel is persistent — ALL state carries across calls: variables, imports, DataFrames, functions. Import once, reuse everywhere.
    - Charts produced here are NOT shown to the user. To display a chart, use \`${previewChartTool.name}\`.
    - No internet access in the sandbox except *.amazonaws.com.
-7. \`${previewChartTool.name}\` — render a chart to the user. This is the ONLY tool that drives the interactive chart viewer. It shares the same kernel/state as \`${executeCodeTool.name}\`, so do analysis there and pass only the plotting code here.
+9. \`${previewChartTool.name}\` — render a chart to the user. This is the ONLY tool that drives the interactive chart viewer. It shares the same kernel/state as \`${executeCodeTool.name}\`, so do analysis there and pass only the plotting code here.
 
 #### Chart Rules (CRITICAL)
 
@@ -108,20 +121,23 @@ To ensure charts render interactively:
    - **Always** render charts on a light background.
 
 ### File Management
-8. \`${shellTool.name}\` — run bash commands in the sandbox. Useful for installing packages, moving files, or quick shell operations.
-9. \`${listFilesTool.name}\`, \`${readFileTool.name}\`, \`${writeFileTool.name}\`, \`${grepTool.name}\`, \`${strReplaceTool.name}\` — file read/write/search in the sandbox.
+10. \`${shellTool.name}\` — run bash commands in the sandbox. Useful for installing packages, moving files, or quick shell operations.
+11. \`${listFilesTool.name}\`, \`${readFileTool.name}\`, \`${writeFileTool.name}\`, \`${grepTool.name}\`, \`${strReplaceTool.name}\` — file read/write/search in the sandbox.
 
 ### Output
-10. Save deliverables (reports, CSVs, charts) to ${OUTPUT_DIR}/ — files here appear in the user's Artifacts panel and are downloadable.
+12. Save deliverables (reports, CSVs, charts) to ${OUTPUT_DIR}/ — files here appear in the user's Artifacts panel and are downloadable.
 
-### Typical Workflow
-\`${searchSignalsTool.name}\` → \`${readSignalTool.name}\` → \`${createWorkspaceTool.name}\` → \`${exportEventsTool.name}\` → \`${executeCodeTool.name}\` (load + analyze) → \`${previewChartTool.name}\` (display charts)
+### Typical Workflows
+- Events: \`${searchSignalsTool.name}\` → \`${readSignalTool.name}\` → \`${createWorkspaceTool.name}\` → \`${exportEventsTool.name}\` → \`${executeCodeTool.name}\` → \`${previewChartTool.name}\`
+- Briefings: \`${searchSignalsTool.name}\` (classificationTypes: TOPIC) → \`${readSignalTool.name}\` → \`${listNewslettersTool.name}\` → \`${readNewsletterTool.name}\`
 
 ### Common Mistakes to Avoid
 - Calling \`${executeCodeTool.name}\` before \`${createWorkspaceTool.name}\`.
+- Using \`${exportEventsTool.name}\` on TOPIC signals — use newsletter tools instead.
+- Using \`${listNewslettersTool.name}\` on EVENT/MENTIONS signals.
 - Using \`${exportEventsTool.name}\` without first calling \`${readSignalTool.name}\` to understand the schema.
 - Using \`${executeCodeTool.name}\` to render charts — charts are only shown to the user via \`${previewChartTool.name}\`.
 - Using \`plt.subplots()\` or combining chart types — make separate \`${previewChartTool.name}\` calls instead.
 - Inventing workspace IDs instead of using the one from \`${createWorkspaceTool.name}\`.
-- Writing raw SQL — all data access goes through \`${exportEventsTool.name}\`.
+- Writing raw SQL — event data access goes through \`${exportEventsTool.name}\`.
 `;

--- a/worker/mcp/tools/index.ts
+++ b/worker/mcp/tools/index.ts
@@ -168,6 +168,8 @@ import { ToolDefinition } from "./types";
 import { createWorkspaceTool } from "./signals/create-workspace";
 import { searchSignalsTool } from "./signals/search-signals";
 import { readSignalTool } from "./signals/read-signal";
+import { listNewslettersTool } from "./signals/list-newsletters";
+import { readNewsletterTool } from "./signals/read-newsletter";
 import { exportEventsTool } from "./signals/export-events";
 import { executeCodeTool } from "./signals/execute-code";
 import { previewChartTool } from "./signals/preview-chart";
@@ -238,6 +240,8 @@ export const TOOL_DEFINITIONS: Record<string, ToolDefinition<any>> = {
   signal_insights_create_workspace: signalStub(createWorkspaceTool),
   signal_insights_search_signals: signalStub(searchSignalsTool),
   signal_insights_read_signal: signalStub(readSignalTool),
+  signal_insights_list_newsletters: signalStub(listNewslettersTool),
+  signal_insights_read_newsletter: signalStub(readNewsletterTool),
   signal_insights_export_events: signalStub(exportEventsTool),
   signal_insights_execute_code: signalStub(executeCodeTool),
   signal_insights_preview_chart: signalStub(previewChartTool),

--- a/worker/mcp/tools/signals/export-events.ts
+++ b/worker/mcp/tools/signals/export-events.ts
@@ -7,6 +7,7 @@ export const exportEventsTool = {
   name: "signal_insights_export_events",
   description:
     "Export signal events using a structured query API. No raw SQL — specify signals, fields, filters, aggregations, and ordering. " +
+    "EVENT and MENTIONS signals only — TOPIC (briefing) signals will error; use signal_insights_list_newsletters / signal_insights_read_newsletter instead. " +
     "Returns a preview of the first rows plus an S3 file path for the full dataset (JSONL). " +
     "Available fields: eventType, eventDate, createdAt, updatedAt, summary, uuid, data, articles, signalId, or data.<path> for JSONB subfields (e.g. data.companyName). " +
     "Filter options: eventTypes (list), date ranges (eventDateFrom/To, createdAtFrom/To), JSONB containment (data: [{op: CONTAINS, value: {key: val}}]). " +

--- a/worker/mcp/tools/signals/index.ts
+++ b/worker/mcp/tools/signals/index.ts
@@ -3,6 +3,8 @@ export type { SignalToolDefinition } from "./types";
 export { createWorkspaceTool } from "./create-workspace";
 export { searchSignalsTool } from "./search-signals";
 export { readSignalTool } from "./read-signal";
+export { listNewslettersTool } from "./list-newsletters";
+export { readNewsletterTool } from "./read-newsletter";
 export { exportEventsTool } from "./export-events";
 export { executeCodeTool } from "./execute-code";
 export { previewChartTool } from "./preview-chart";
@@ -17,6 +19,8 @@ import type { SignalToolDefinition } from "./types";
 import { createWorkspaceTool } from "./create-workspace";
 import { searchSignalsTool } from "./search-signals";
 import { readSignalTool } from "./read-signal";
+import { listNewslettersTool } from "./list-newsletters";
+import { readNewsletterTool } from "./read-newsletter";
 import { exportEventsTool } from "./export-events";
 import { executeCodeTool } from "./execute-code";
 import { previewChartTool } from "./preview-chart";
@@ -26,12 +30,13 @@ import { grepTool } from "./grep";
 import { readFileTool } from "./read-file";
 import { writeFileTool } from "./write-file";
 import { strReplaceTool } from "./str-replace";
-import z from "zod";
 
 export const SIGNAL_TOOL_DEFINITIONS = {
   [createWorkspaceTool.name]: createWorkspaceTool,
   [searchSignalsTool.name]: searchSignalsTool,
   [readSignalTool.name]: readSignalTool,
+  [listNewslettersTool.name]: listNewslettersTool,
+  [readNewsletterTool.name]: readNewsletterTool,
   [exportEventsTool.name]: exportEventsTool,
   [executeCodeTool.name]: executeCodeTool,
   [previewChartTool.name]: previewChartTool,

--- a/worker/mcp/tools/signals/list-newsletters.ts
+++ b/worker/mcp/tools/signals/list-newsletters.ts
@@ -1,0 +1,15 @@
+import { SignalToolDefinition } from "./types";
+import { listNewslettersSchema } from "./schemas";
+
+export const listNewslettersTool = {
+  name: "signal_insights_list_newsletters",
+  description:
+    "List newsletters (briefings) for a TOPIC signal. " +
+    "Returns title, short excerpt (~500 chars), and timestamps — not full content. " +
+    "Only works for TOPIC signals; EVENT and MENTIONS will error. " +
+    "Use after signal_insights_read_signal confirms classificationType is TOPIC, " +
+    "then call signal_insights_read_newsletter for full content.",
+  parameters: listNewslettersSchema,
+  createHandler: (insightsApi) => async (args) =>
+    insightsApi.listNewsletters(args),
+} as const satisfies SignalToolDefinition<typeof listNewslettersSchema>;

--- a/worker/mcp/tools/signals/read-newsletter.ts
+++ b/worker/mcp/tools/signals/read-newsletter.ts
@@ -1,0 +1,16 @@
+import { SignalToolDefinition } from "./types";
+import { readNewsletterSchema } from "./schemas";
+import { listNewslettersTool } from "./list-newsletters";
+
+export const readNewsletterTool = {
+  name: "signal_insights_read_newsletter",
+  description:
+    "Fetch a full newsletter by UUID and return it as markdown (YAML frontmatter + body). " +
+    `Use after ${listNewslettersTool.name} to get complete briefing content for context or analysis. ` +
+    "Only works for newsletters belonging to TOPIC signals.",
+  parameters: readNewsletterSchema,
+  createHandler:
+    (insightsApi) =>
+    async ({ newsletterUuid }) =>
+      insightsApi.readNewsletter(newsletterUuid),
+} as const satisfies SignalToolDefinition<typeof readNewsletterSchema>;

--- a/worker/mcp/tools/signals/read-signal.ts
+++ b/worker/mcp/tools/signals/read-signal.ts
@@ -1,12 +1,12 @@
 import { SignalToolDefinition } from "./types";
 import { readSignalSchema } from "./schemas";
-import { exportEventsTool } from "./export-events";
 
 export const readSignalTool = {
   name: "signal_insights_read_signal",
   description:
-    "Get full signal metadata including data schema, available event types, and event count. " +
-    `Use before ${exportEventsTool.name} to understand the available fields for a signal.`,
+    "Get full signal metadata including classificationType and type-specific fields. " +
+    "EVENT/MENTIONS: data schema, event types, event count — use before export_events. " +
+    "TOPIC: newsletterCount and date range — use list_newsletters / read_newsletter.",
   parameters: readSignalSchema,
   createHandler:
     (insightsApi) =>

--- a/worker/mcp/tools/signals/schemas.ts
+++ b/worker/mcp/tools/signals/schemas.ts
@@ -28,6 +28,13 @@ export const searchSignalsSchema = z.object({
       "Search term matched against signal name or monitoring objective. " +
         "Case-insensitive. Omit to list all available signals.",
     ),
+  classificationTypes: z
+    .array(z.enum(["EVENT", "MENTIONS", "TOPIC"]))
+    .optional()
+    .describe(
+      "Filter by signal classification. Omit for all types. " +
+        "EVENT/MENTIONS = structured events; TOPIC = briefings/newsletters.",
+    ),
   page: z.number().int().min(0).default(0).optional(),
   limit: z.number().int().min(1).max(50).default(10).optional(),
 });
@@ -37,6 +44,26 @@ export const readSignalSchema = z.object({
     .string()
     .uuid()
     .describe("UUID of the signal to read. Use search_signals to find UUIDs."),
+});
+
+export const listNewslettersSchema = z.object({
+  signalUuid: z
+    .string()
+    .uuid()
+    .describe(
+      "UUID of a TOPIC signal. Use search_signals / read_signal to confirm classificationType is TOPIC.",
+    ),
+  page: z.number().int().min(0).default(0).optional(),
+  limit: z.number().int().min(1).max(50).default(10).optional(),
+});
+
+export const readNewsletterSchema = z.object({
+  newsletterUuid: z
+    .string()
+    .uuid()
+    .describe(
+      "UUID of the newsletter. Use signal_insights_list_newsletters to find UUIDs.",
+    ),
 });
 
 // ── Export ───────────────────────────────────────────────────────────────────

--- a/worker/mcp/tools/signals/search-signals.ts
+++ b/worker/mcp/tools/signals/search-signals.ts
@@ -5,6 +5,8 @@ export const searchSignalsTool = {
   name: "signal_insights_search_signals",
   description:
     "Search for signals by name or monitoring objective. " +
+    "Optional classificationTypes filter: EVENT, MENTIONS, TOPIC (briefings). Omit for all types. " +
+    "Results include classificationType, eventCount, and newsletterCount. " +
     "Use this to find relevant signals before fetching data. " +
     "If the search query is not present, this can be used to list all available signals.",
   parameters: searchSignalsSchema,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

Adds Signal Insights support for discovering TOPIC signals and reading their newsletter briefings. User-visible: yes — customers can now list and read briefing content through MCP. Watch newsletter frontmatter formatting for titles or signal names that resemble YAML values after rollout.
<!-- release-category: new-user-facing-capability -->

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking newsletter frontmatter escaping issue worth correcting.

The new TOPIC discovery and newsletter tools are consistently registered and validated, but YAML-like newsletter names can be represented with the wrong type or malformed metadata.

**Files Needing Attention:** worker/lib/format-newsletter.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| worker/lib/insights-api-client.ts | Adds TOPIC filtering and authenticated endpoints for listing and reading newsletters. |
| worker/lib/format-newsletter.ts | Formats newsletters as markdown, but its YAML escaping does not preserve every valid string scalar. |
| worker/mcp/tools/signals/schemas.ts | Adds validated TOPIC classification filters, pagination, and newsletter UUID schemas. |
| worker/mcp/tools/signals/list-newsletters.ts | Exposes the stateless MCP tool for listing TOPIC newsletters. |
| worker/mcp/tools/signals/read-newsletter.ts | Exposes the stateless MCP tool for retrieving complete newsletter content. |
| worker/mcp/instructions.ts | Documents separate event and TOPIC briefing workflows for MCP clients. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant MCP as Signal Insights MCP
  participant API as Insights API
  User->>MCP: "search_signals(classificationTypes=[TOPIC])"
  MCP->>API: GET /search
  API-->>MCP: TOPIC signals
  User->>MCP: list_newsletters(signalUuid)
  MCP->>API: "GET /{signalUuid}/newsletters"
  API-->>MCP: Newsletter summaries
  User->>MCP: read_newsletter(newsletterUuid)
  MCP->>API: "GET /newsletters/{newsletterUuid}"
  API-->>MCP: Full newsletter
  MCP-->>User: Markdown with YAML frontmatter
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
worker/lib/format-newsletter.ts:29-34
**Quote YAML-like metadata values**

The hand-written escaping leaves YAML-reserved plain scalar forms such as `true`, `null`, `2024`, leading `- `, and surrounding whitespace unquoted. Newsletter titles or signal names using these forms are coerced, trimmed, or rejected by YAML consumers, so downstream analysis receives metadata that no longer preserves the API's original string values.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add insights topic support"](https://github.com/goperigon/perigon-mcp-server/commit/8ba90e9779a99949c2fc9c6fa673dc8e72230c76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47617639)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->